### PR TITLE
Supports api response specification changes

### DIFF
--- a/lib/arisaid/userable.rb
+++ b/lib/arisaid/userable.rb
@@ -7,7 +7,7 @@ module Arisaid
     end
 
     def users!
-      @users = client.users.select { |u|
+      @users = client.users.members.select { |u|
         u.deleted == false && u.is_bot == false && u.is_restricted == false
       }
     end


### PR DESCRIPTION
APIのレスポンスに `status :ok` などが含まれるようになって（素でmembersやusergroupsの羅列が帰ってくるわけではなくなった？）みたいなのでほしい要素を取得するように変更しました。その関係で取り扱う変数がハッシュになったので、メソッドチェーンが使えなくなったところを修正しました。